### PR TITLE
Add simple PCF button control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# ButtonClickpcf
+# GetWellDetails PCF Control
+
+This repository contains a simple PowerApps Component Framework (PCF) control
+that renders a button labelled **"Get Well Details"**. When the button is
+clicked it attempts to execute a global JavaScript function named
+`getwelldata`.
+
+The control can be used to trigger custom logic in a model driven app or
+canvas app. Ensure that a function named `getwelldata` is available on the
+page where the control is used.
+
+## Build
+
+Install dependencies and compile the TypeScript:
+
+```bash
+npm install
+npm run build
+```
+
+The compiled files will be placed in the `dist` folder.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "button-click-pcf",
+  "version": "1.0.0",
+  "description": "PCF control that renders a button and invokes getwelldata on click",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/GetWellDetailsControl.ts
+++ b/src/GetWellDetailsControl.ts
@@ -1,0 +1,48 @@
+import { IInputs, IOutputs } from "./generated/ManifestTypes";
+
+export class GetWellDetailsControl implements ComponentFramework.StandardControl<IInputs, IOutputs> {
+    private _container: HTMLDivElement;
+
+    constructor() {}
+
+    public init(
+        context: ComponentFramework.Context<IInputs>,
+        notifyOutputChanged: () => void,
+        state: ComponentFramework.Dictionary,
+        container: HTMLDivElement
+    ): void {
+        this._container = container;
+    }
+
+    public updateView(context: ComponentFramework.Context<IInputs>): void {
+        while (this._container.firstChild) {
+            this._container.removeChild(this._container.firstChild);
+        }
+
+        const button = document.createElement("button");
+        button.innerText = "Get Well Details";
+        button.addEventListener("click", () => {
+            try {
+                const fn = (window as any).getwelldata;
+                if (typeof fn === "function") {
+                    fn();
+                } else {
+                    console.error("getwelldata function is not defined");
+                }
+            } catch (e) {
+                console.error("Error executing getwelldata", e);
+            }
+        });
+        this._container.appendChild(button);
+    }
+
+    public getOutputs(): IOutputs {
+        return {} as IOutputs;
+    }
+
+    public destroy(): void {
+        while (this._container.firstChild) {
+            this._container.removeChild(this._container.firstChild);
+        }
+    }
+}

--- a/src/css/GetWellDetails.css
+++ b/src/css/GetWellDetails.css
@@ -1,0 +1,8 @@
+button {
+    padding: 10px 15px;
+    background-color: #0078d4;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}

--- a/src/generated/ManifestTypes.ts
+++ b/src/generated/ManifestTypes.ts
@@ -1,0 +1,5 @@
+export interface IInputs {
+}
+
+export interface IOutputs {
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- create GetWellDetails PCF control skeleton
- add TypeScript, manifest type stubs and CSS
- document build steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc` *(fails: cannot find namespace 'ComponentFramework')*

------
https://chatgpt.com/codex/tasks/task_e_6853ec657d8c832c9ad93799c58b9e8c