### PR TITLE
Fix manifest property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ The root `controlManifest.input.xml` file describes the control for the
 PowerApps build tools. The `build` script expects `pcf-scripts` to be
 installed. If it is not available the build will fail with `pcf-scripts: not
 found`.
+
+The manifest uses plain `display-name` attributes for the control properties,
+so no additional localization resources are required.

--- a/controlManifest.input.xml
+++ b/controlManifest.input.xml
@@ -7,7 +7,7 @@
       <code path="dist/GetWellDetailsControl.js" order="1" />
       <css path="src/css/GetWellDetails.css" order="2" />
     </resources>
-    <property name="rpc_wellapi" display-name-key="rpc_wellapi" type="SingleLine.Text" usage="bound" />
-    <property name="rpc_wellnumber" display-name-key="rpc_wellnumber" type="SingleLine.Text" usage="bound" />
+    <property name="rpc_wellapi" display-name="rpc_wellapi" type="SingleLine.Text" usage="bound" />
+    <property name="rpc_wellnumber" display-name="rpc_wellnumber" type="SingleLine.Text" usage="bound" />
   </control>
 </manifest>


### PR DESCRIPTION
## Summary
- use `display-name` instead of `display-name-key` in manifest
- document that localization resources are not needed

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: pcf-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855208eec5c832cae1e6d371fc5958b